### PR TITLE
Update tag-messages.js to have the funny extension manager button thing

### DIFF
--- a/src/lib/libraries/tag-messages.js
+++ b/src/lib/libraries/tag-messages.js
@@ -206,6 +206,11 @@ export default defineMessages({
         description: 'Button that loads a custom extension.',
         id: 'gui.libraryTags.customextension'
     },
+    extensionmanager: {
+        defaultMessage: 'Manage Loaded Extensions',
+        description: 'Button that lets you manage extensions in the project.',
+        id: 'gui.libraryTags.extensionmanager'
+    },
     hardware: {
         defaultMessage: 'Hardware',
         description: 'Tag for filtering a library by hardware.',


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves nothing 

### Proposed Changes

Adds the tag message for the upcoming button for managing extensions :)

### Reason for Changes

Convenience.

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [X] Chrome 
 * [X] Firefox 
 * [X] Safari
 
Windows
 * [X] Chrome 
 * [X] Firefox 
 * [X] Edge
 
Chromebook
 * [X] Chrome
 
iPad
* [X] Safari

Android Tablet
* [X] Chrome
