### PR TITLE
make stage size selector scroll horizontally

### DIFF
--- a/src/components/tw-settings-modal/settings-modal.css
+++ b/src/components/tw-settings-modal/settings-modal.css
@@ -185,3 +185,12 @@
 [theme="dark"] .warning {
     background: rgb(114, 102, 0);
 }
+.scrollContainer {
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
+.scrollContent {
+    display: inline-flex;
+    gap: 10px;
+}

--- a/src/components/tw-settings-modal/settings-modal.jsx
+++ b/src/components/tw-settings-modal/settings-modal.jsx
@@ -334,54 +334,56 @@ const CustomStageSize = ({
                     description="Stage Size option"
                     id="pm.settingsModal.stageSize"
                 />
-                <div>
-                    <button
-                        className={styles.customStageSizeButton}
-                        data-selected={stageWidth === 360 && stageHeight === 360}
-                        data-square={true}
-                        onClick={() => onStagePresetUsed(2)}
-                    >
-                        1:1
-                    </button>
-                    <button
-                        className={styles.customStageSizeButton}
-                        data-selected={stageWidth === 480 && stageHeight === 360}
-                        onClick={() => onStagePresetUsed(0)}
-                    >
-                        4:3
-                    </button>
-                    <button
-                        className={styles.customStageSizeButton}
-                        data-selected={stageWidth === 640 && stageHeight === 360}
-                        data-widescreen={true}
-                        onClick={() => onStagePresetUsed(1)}
-                    >
-                        16:9
-                    </button>
-                    <button
-                        className={styles.customStageSizeButton}
-                        data-selected={stageWidth === 360 && stageHeight === 640}
-                        data-mobile={true}
-                        onClick={() => onStagePresetUsed(3)}
-                    >
-                        9:16
-                    </button>
-                    <button
-                        className={styles.customStageSizeButton}
-                        data-selected={stageWidth === 360 && stageHeight === 720}
-                        data-mobile-alt={true}
-                        onClick={() => onStagePresetUsed(4)}
-                    >
-                        9:18
-                    </button>
-                    <button
-                        className={styles.customStageSizeButton}
-                        data-selected={stageWidth === 360 && stageHeight === 450}
-                        data-mobile-small={true}
-                        onClick={() => onStagePresetUsed(5)}
-                    >
-                        4:5
-                    </button>
+                <div className={styles.scrollContainer}>
+                    <div className={styles.scrollContent}>
+                        <button
+                            className={styles.customStageSizeButton}
+                            data-selected={stageWidth === 360 && stageHeight === 360}
+                            data-square={true}
+                            onClick={() => onStagePresetUsed(2)}
+                        >
+                            1:1
+                        </button>
+                        <button
+                            className={styles.customStageSizeButton}
+                            data-selected={stageWidth === 480 && stageHeight === 360}
+                            onClick={() => onStagePresetUsed(0)}
+                        >
+                            4:3
+                        </button>
+                        <button
+                            className={styles.customStageSizeButton}
+                            data-selected={stageWidth === 640 && stageHeight === 360}
+                            data-widescreen={true}
+                            onClick={() => onStagePresetUsed(1)}
+                        >
+                            16:9
+                        </button>
+                        <button
+                            className={styles.customStageSizeButton}
+                            data-selected={stageWidth === 360 && stageHeight === 640}
+                            data-mobile={true}
+                            onClick={() => onStagePresetUsed(3)}
+                        >
+                            9:16
+                        </button>
+                        <button
+                            className={styles.customStageSizeButton}
+                            data-selected={stageWidth === 360 && stageHeight === 720}
+                            data-mobile-alt={true}
+                            onClick={() => onStagePresetUsed(4)}
+                        >
+                            9:18
+                        </button>
+                        <button
+                            className={styles.customStageSizeButton}
+                            data-selected={stageWidth === 360 && stageHeight === 450}
+                            data-mobile-small={true}
+                            onClick={() => onStagePresetUsed(5)}
+                        >
+                            4:5
+                        </button>
+                    </div>
                 </div>
                 <div className={styles.customStageSizeContainer}>
                     <FormattedMessage
@@ -415,7 +417,6 @@ const CustomStageSize = ({
             (stageWidth >= 1000 || stageHeight >= 1000) && (
                 <div className={styles.warning}>
                     <FormattedMessage
-                        // eslint-disable-next-line max-len
                         defaultMessage="Using a custom stage size this large is not recommended! Instead, use a lower size with the same aspect ratio and let fullscreen mode upscale it to match the user's display."
                         description="Warning about using stages that are too large in settings modal"
                         id="tw.settingsModal.largeStageWarning"
@@ -426,7 +427,6 @@ const CustomStageSize = ({
         }
         help={(
             <FormattedMessage
-                // eslint-disable-next-line max-len
                 defaultMessage="Changes the size of the Scratch stage from 480x360 to something else. Try 640x360 to make the stage widescreen. Very few projects will handle this properly."
                 description="Custom Stage Size option"
                 id="tw.settingsModal.customStageSizeHelp"
@@ -435,6 +435,7 @@ const CustomStageSize = ({
         slug="custom-stage-size"
     />
 );
+
 CustomStageSize.propTypes = {
     customStageSizeEnabled: PropTypes.bool,
     stageWidth: PropTypes.number,

--- a/src/components/tw-settings-modal/settings-modal.jsx
+++ b/src/components/tw-settings-modal/settings-modal.jsx
@@ -417,6 +417,7 @@ const CustomStageSize = ({
             (stageWidth >= 1000 || stageHeight >= 1000) && (
                 <div className={styles.warning}>
                     <FormattedMessage
+                        // eslint-disable-next-line max-len
                         defaultMessage="Using a custom stage size this large is not recommended! Instead, use a lower size with the same aspect ratio and let fullscreen mode upscale it to match the user's display."
                         description="Warning about using stages that are too large in settings modal"
                         id="tw.settingsModal.largeStageWarning"
@@ -427,6 +428,7 @@ const CustomStageSize = ({
         }
         help={(
             <FormattedMessage
+                // eslint-disable-next-line max-len
                 defaultMessage="Changes the size of the Scratch stage from 480x360 to something else. Try 640x360 to make the stage widescreen. Very few projects will handle this properly."
                 description="Custom Stage Size option"
                 id="tw.settingsModal.customStageSizeHelp"


### PR DESCRIPTION
### Resolves

no issue for this

- Resolves #

### Proposed Changes

it basically makes the stage size selector able to scroll horizontally (hopefully) (idk i didnt really test it so erm..) (cuz idk how to test things in react)

### Reason for Changes

i feel like it would be better

### Test Coverage

erm.... i kinda didnt cuz idk how to test react code lol!!!!!!!!!!

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

will update soon when vercel published it when i make this pr

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
